### PR TITLE
build: specify supported npm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "prettier": "2.2.1"
   },
   "engines": {
-    "node": ">=14.15.4"
+    "node": ">=14.15.4",
+    "npm": "^6.14.11"
   },
   "scripts": {
     "lint": "prettier --check .",


### PR DESCRIPTION
<!-- You can put a tick in a checkbox like this: [X] -->

## Checklist

- [ ] I've linked the upstream Proton issue report in the context section of this pull request.

## Changes

- Specify which version of npm this project uses

## Context

<!-- If you're fixing an issue, use the Fixes keyword: Fixes #1 -->

This prevents Renovate bot from opening PRs which use a wrong version of npm.
