### PR TITLE
chore(config): simplify config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,6 @@
 {
   "extends": ["config:base", "helpers:pinGitHubActionDigests"],
   "prCreation": "not-pending",
-  "internalChecksFilter": "strict",
   "packageRules": [
     {
       "description": "Wait 3 days before creating a npm update PR",


### PR DESCRIPTION
## Changes

- Drop `internalChecksFilter=strict`, because it became default behavior

## Context

Use default Renovate behavior.
