### PR TITLE
ci: bump node.js version in tests

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x]
+        node-version: [18.x]
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Changes

- Use node 18 in the test matrix

## Context

Node.js 14 is end of life, so I'm updating to node 18.
