### PR TITLE
chore: update Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,10 @@
 {
-  "extends": ["config:base", "helpers:pinGitHubActionDigests"],
-  "prCreation": "not-pending",
+  "extends": ["config:best-practices"],
   "packageRules": [
     {
       "description": "Wait 3 days before creating a npm update PR",
       "matchDatasources": ["npm"],
-      "stabilityDays": 3
+      "minimumReleaseAge": "3 days"
     }
   ]
 }


### PR DESCRIPTION
## Checklist

- [x] I've linked the upstream Proton issue report in the context section of this pull request.

## Changes

- Use `config:best-practices` instead of `config:base`
- Drop `helpers:pinGitHubActionDigests` because it's included in `config:best-practices`
- Remove `prCreation=not-pending` and rely on default behavior
- Use `minimumReleaseAge` instead of `stabilityDays`

## Context

Time to update the Renovate configuration.