### PR TITLE
ci: update Node.js to 20

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [20.x]
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
<!-- You can put a tick in a checkbox like this: [X] -->

## Checklist

- [x] I've linked the upstream Proton issue report in the context section of this pull request.

## Changes

- Node.js 20 is latest LTS

## Context

Update Node.js to latest LTS.
